### PR TITLE
8.2: Fix package installation and removal

### DIFF
--- a/SOURCES/netdata-1.19.0-handle-systemd-unit-stop.XCP-ng.patch
+++ b/SOURCES/netdata-1.19.0-handle-systemd-unit-stop.XCP-ng.patch
@@ -1,0 +1,15 @@
+diff --git a/system/netdata.service.in b/system/netdata.service.in
+index 611ee90..ade1c87 100644
+--- a/system/netdata.service.in
++++ b/system/netdata.service.in
+@@ -21,6 +21,10 @@ ExecStartPre=/bin/chown -R netdata:netdata @localstatedir_POST@/run/netdata
+ ExecStartPre=/usr/libexec/netdata/xcpng-iptables-restore.sh
+ #ExecStopPost=/bin/rm @localstatedir_POST@/run/netdata/netdata.pid
+ PermissionsStartOnly=true
++# XCP-ng: Add a delay before stopping netdata to avoid the service to hang and
++# be in a failed state if stop is called too soon after a start.
++ExecStop=/usr/bin/sleep 3
++ExecStop=/usr/bin/kill --signal SIGTERM $MAINPID
+ 
+ # saving a big db on slow disks may need some time
+ TimeoutStopSec=60

--- a/SPECS/netdata.spec
+++ b/SPECS/netdata.spec
@@ -86,7 +86,7 @@ fi \
 Summary:	Real-time performance monitoring, done right!
 Name:		netdata
 Version:	1.19.0
-Release:	5%{?dist}
+Release:	6%{?dist}
 License:	GPLv3+
 Group:		Applications/System
 Source0:	https://github.com/netdata/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
@@ -112,6 +112,8 @@ Patch1002:	netdata-1.19.0-remove-tmem-data-collection.XCP-ng.patch
 Patch1003:	netdata-1.19.0-correctly-track-last-num-vcpus-in-xenstat_plugin.backport.patch
 # Fix security vulnerability
 Patch1004:	netdata-1.19.0-fix-critical-vulnerability-in-json-parsing.backport.patch
+# Fix start/stop netdata service
+Patch1005:  netdata-1.19.0-handle-systemd-unit-stop.XCP-ng.patch
 
 # #####################################################################
 # Core build/install/runtime dependencies
@@ -517,6 +519,9 @@ fi
 %config(noreplace) /etc/sysconfig/ip6tables_netdata
 
 %changelog
+* Fri Nov 08 2024 Thierry Escande <thierry.escande@vates.tech> - 1.19.0-6
+- Handle service ExecStop to avoid service to hang when removing packages
+
 * Thu Jul 16 2020 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.19.0-5
 - Fix vulnerability in JSON parsing (buffer overflow)
 - Fix log flood


### PR DESCRIPTION
When removing netdata and netdata-ui packages together (same yum transaction), the netdata service is restarted by the ui package then stopped immediately after by the removal the netdata package. This could make the service to hang and leave it in a failed state and not entirely removed. This patch adds a delay of 3 seconds before killing the main netdata process. This give enough time to netdata to start before being stopped.