### PR TITLE
8.3: Fix package installation and removal

### DIFF
--- a/SOURCES/netdata-v1.44.3-handle-systemd-unit-stop.XCP-ng.patch
+++ b/SOURCES/netdata-v1.44.3-handle-systemd-unit-stop.XCP-ng.patch
@@ -1,0 +1,15 @@
+diff --git a/system/systemd/netdata.service.v235.in b/system/systemd/netdata.service.v235.in
+index 3d52677..055406d 100644
+--- a/system/systemd/netdata.service.v235.in
++++ b/system/systemd/netdata.service.v235.in
+@@ -13,6 +13,10 @@ EnvironmentFile=-/etc/default/netdata
+ ExecStart=@sbindir_POST@/netdata -D $EXTRA_OPTS
+ # XCP-ng: call script that will load /etc/sysconfig/iptables_netdata if it exists
+ ExecStartPre=/usr/libexec/netdata/xcpng-iptables-restore.sh
++# XCP-ng: Add a delay before stopping netdata to avoid the service to hang and
++# be in a failed state if stop is called too soon after a start.
++ExecStop=/usr/bin/sleep 3
++ExecStop=/usr/bin/kill --signal SIGTERM $MAINPID
+ 
+ # saving a big db on slow disks may need some time
+ TimeoutStopSec=150

--- a/SPECS/netdata.spec
+++ b/SPECS/netdata.spec
@@ -55,7 +55,7 @@ ExcludeArch: s390x
 
 Name:           netdata
 Version:        %{upver}%{?rcver:~%{rcver}}
-Release:        1.1%{?dist}
+Release:        1.2%{?dist}
 Summary:        Real-time performance monitoring
 # For a breakdown of the licensing, see license REDISTRIBUTED.md
 License:        GPL-3.0-only
@@ -89,6 +89,7 @@ Patch10:        netdata-remove-fonts-1.41.0.patch
 # XCP-ng specific patches
 Patch1000:      fix-gcc4-static-struct-init.XCP-ng.patch
 Patch1001:      netdata-v1.44.3-firewall-management-in-systemd-unit.XCP-ng.patch
+Patch1002:      netdata-v1.44.3-handle-systemd-unit-stop.XCP-ng.patch
 
 BuildRequires:  zlib-devel
 BuildRequires:  git
@@ -274,6 +275,7 @@ rm -rf web/fonts web/gui/dashboard/static/media
 %endif
 %patch1000 -p1
 %patch1001 -p1
+%patch1002 -p1
 cp %{SOURCE5} .
 ### BEGIN netdata cloud
 %if %{with bundled_protobuf}
@@ -533,6 +535,9 @@ fi
 %caps(cap_setuid=ep) %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 
 %changelog
+* Fri Nov 08 2024 Thierry Escande <thierry.escande@vates.tech> - 1.44.3-1.2
+- Handle service ExecStop to avoid service to hang when removing packages
+
 * Fri May 24 2024 Thierry Escande <thierry.escande@vates.tech> - 1.44.3-1.1
 - Fix build errors with gcc 4.8
 - Force use of protobuf system packages from XCP-ng repositories


### PR DESCRIPTION
When removing netdata and netdata-ui packages together (same yum transaction), the netdata service is restarted by the ui package then stopped immediately after by the removal the netdata package. This could make the service to hang and leave it in a failed state and not entirely removed. This patch adds a delay of 3 seconds before killing the main netdata process. This give enough time to netdata to start before being stopped.