### PR TITLE
8.2: Add systemd netdata service stop script

### DIFF
--- a/SOURCES/netdata-v1.44.3-handle-systemd-unit-stop.XCP-ng.patch
+++ b/SOURCES/netdata-v1.44.3-handle-systemd-unit-stop.XCP-ng.patch
@@ -6,9 +6,9 @@ index 3d52677..055406d 100644
  ExecStart=@sbindir_POST@/netdata -D $EXTRA_OPTS
  # XCP-ng: call script that will load /etc/sysconfig/iptables_netdata if it exists
  ExecStartPre=/usr/libexec/netdata/xcpng-iptables-restore.sh
-+# XCP-ng: Add a delay before stopping netdata to avoid the service to hang and
-+# be in a failed state if stop is called too soon after a start.
-+ExecStop=/usr/bin/sleep 10
++# XCP-ng: Make sure netdata is up and running before stopping it to avoid the
++# service to be in failed state if stop is called too soon after a start.
++ExecStop=/usr/libexec/netdata/netdata-wait-up-and-running.sh
 +ExecStop=/usr/bin/kill --signal SIGTERM $MAINPID
  
  # saving a big db on slow disks may need some time

--- a/SOURCES/netdata-wait-up-and-running.sh
+++ b/SOURCES/netdata-wait-up-and-running.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script waits for netdata to be up and running by waiting for
+# the xenstat plugin to be loaded and executed, then exits or timeouts
+# after 20 seconds. It exits immediately if netdata is not running.
+#
+# This script is intended to be used by systemd as ExecStop program to
+# delay the termination of netdata while it is starting (i.e. calling
+# 'systemctl start' and 'systemctl stop' immediately after).
+
+[ -z "${MAINPID}" ] && exit 0
+
+XENSTAT_PLUGIN=xenstat.plugin
+
+MAX_WAIT=20
+WAIT=0
+
+while [ ${WAIT} -lt ${MAX_WAIT} ] &&
+      [ -d /proc/${MAINPID} ] &&
+      ! pstree ${MAINPID} | grep -q ${XENSTAT_PLUGIN}; do
+    sleep 1
+    ((WAIT++))
+done
+
+# If we've been waiting on xenstat.plugin, just wait a bit more
+# to make sure we're really started (but not if we timeout'd)
+[ ${WAIT} -gt 0 ] && [ ${WAIT} -lt ${MAX_WAIT} ] && sleep 3
+
+exit 0

--- a/SPECS/netdata.spec
+++ b/SPECS/netdata.spec
@@ -55,7 +55,7 @@ ExcludeArch: s390x
 
 Name:           netdata
 Version:        %{upver}%{?rcver:~%{rcver}}
-Release:        1.1%{?dist}
+Release:        1.2%{?dist}
 Summary:        Real-time performance monitoring
 # For a breakdown of the licensing, see license REDISTRIBUTED.md
 License:        GPL-3.0-only
@@ -79,6 +79,7 @@ Source1001:     netdata.conf.ui
 Source1002:     xcpng-iptables-restore.sh
 Source1003:     iptables_netdata
 Source1004:     ip6tables_netdata
+Source1005:     netdata-wait-up-and-running.sh
 
 Patch0:         netdata-fix-shebang-1.41.0.patch
 %if 0%{?fedora}
@@ -167,6 +168,9 @@ Requires:       glyphicons-halflings-fonts
 %endif
 Requires:       logrotate
 Requires:       libyaml
+
+# XCP-ng: for pstree needed by netdata-wait-up-and-running.sh
+Requires:       psmisc
 
 Requires:       %{name}-data = %{version}-%{release}
 Requires:       %{name}-conf = %{version}-%{release}
@@ -388,6 +392,9 @@ install -d %{buildroot}%{_sysconfdir}/sysconfig
 install -m 600 %{SOURCE1003} %{buildroot}%{_sysconfdir}/sysconfig/iptables_netdata
 install -m 600 %{SOURCE1004} %{buildroot}%{_sysconfdir}/sysconfig/ip6tables_netdata
 
+# XCP-ng: systemd delay stop script
+install -m 755 %{SOURCE1005} %{buildroot}%{_libexecdir}/%{name}/netdata-wait-up-and-running.sh
+
 # Scripts must not be in /etc, /usr/libexec is a better place
 mv %{buildroot}%{_sysconfdir}/%{name}/edit-config %{buildroot}%{_libexecdir}/%{name}/edit-config
 # Fix EOL
@@ -501,6 +508,7 @@ fi
 %attr(0750,root,netdata)%{_sbindir}/netdata-install-go-plugins.sh
 %config(noreplace) /etc/sysconfig/iptables_netdata
 %config(noreplace) /etc/sysconfig/ip6tables_netdata
+%{_libexecdir}/%{name}/netdata-wait-up-and-running.sh
 
 %files conf
 %doc README.md
@@ -543,6 +551,9 @@ fi
 %config %{_sysconfdir}/%{name}/%{name}.conf.ui
 
 %changelog
+* Wed Feb 19 2025 Thierry Escande <thierry.escande@vates.tech> - 1.44.3-1.2
+- Replace 'ExecStop=sleep 10' in systemd service unit with a nicer script
+
 * Thu Feb 06 2025 Thierry Escande <thierry.escande@vates.tech> - 1.44.3-1.1
 - Update to netdata v1.44.3
 - Fix build errors with gcc 4.8


### PR DESCRIPTION
This change adds a script that waits for netdata to be up and running by waiting for the xenstat plugin to be loaded and executed, then exits or timeouts after 20 seconds. It exits immediately if netdata is not running.

This script is used by systemd as ExecStop program to delay the termination of netdata while it is starting (i.e. calling 'systemctl start' and 'systemctl stop' immediately after) and avoid the service to hang in a failed state.