### PR TITLE
Remove unsupported LogNamespace systemd service entry

### DIFF
--- a/SOURCES/netdata-v1.47.5-Remove-unsupported-LogNamespace-systemd-service-entr.patch
+++ b/SOURCES/netdata-v1.47.5-Remove-unsupported-LogNamespace-systemd-service-entr.patch
@@ -1,0 +1,31 @@
+From f8ede9cd35a540fa84fd0821afbe43df5b8267ab Mon Sep 17 00:00:00 2001
+From: Thierry Escande <thierry.escande@vates.tech>
+Date: Wed, 1 Oct 2025 14:55:10 +0200
+Subject: [PATCH] Remove unsupported LogNamespace systemd service entry
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+LogNamespace= has been introduced in v245 so it's not supported by
+XCP-ng 8.3 systemd v219. Remove it to avoid warnings when checking
+service units correctness.
+
+Signed-off-by: Thierry Escande <thierry.escande@vates.tech>
+---
+ system/systemd/netdata.service.v235.in | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/system/systemd/netdata.service.v235.in b/system/systemd/netdata.service.v235.in
+index f95a22f..a7f5b18 100644
+--- a/system/systemd/netdata.service.v235.in
++++ b/system/systemd/netdata.service.v235.in
+@@ -7,7 +7,6 @@ After=network.target network-online.target nss-lookup.target
+ Wants=network-online.target nss-lookup.target
+ 
+ [Service]
+-LogNamespace=netdata
+ Type=simple
+ User=root
+ EnvironmentFile=-/etc/default/netdata
+-- 
+2.51.0
+

--- a/SPECS/netdata.spec
+++ b/SPECS/netdata.spec
@@ -68,7 +68,7 @@ ExcludeArch: s390x
 
 Name:           netdata
 Version:        %{upver}%{?rcver:~%{rcver}}
-Release:        4.1%{?dist}
+Release:        4.2%{?dist}
 Summary:        Real-time performance monitoring
 # For a breakdown of the licensing, see license REDISTRIBUTED.md
 License:        GPL-3.0-or-later
@@ -108,6 +108,7 @@ Patch10:        netdata-remove-fonts-1.46.0.patch
 Patch1000:      netdata-v1.47.5-Fix-xcpng-build-for-gcc-4.8.patch
 Patch1001:      netdata-v1.44.3-firewall-management-in-systemd-unit.XCP-ng.patch
 Patch1002:      netdata-v1.44.3-handle-systemd-unit-stop.XCP-ng.patch
+Patch1003:      netdata-v1.47.5-Remove-unsupported-LogNamespace-systemd-service-entr.patch
 
 BuildRequires:  zlib-devel
 BuildRequires:  git
@@ -321,6 +322,7 @@ fi
 %patch1000 -p1
 %patch1001 -p1
 %patch1002 -p1
+%patch1003 -p1
 
 cp %{SOURCE5} .
 ### BEGIN netdata cloud
@@ -641,6 +643,9 @@ fi
 
 
 %changelog
+* Wed Oct 01 2025 Thierry Escande <thierry.escande@vates.tech> - 1.47.5-4.2
+- Remove unsupported LogNamespace systemd service entry
+
 * Wed Feb 19 2025 Thierry Escande <thierry.escande@vates.tech> - 1.47.5-4.1
 - Update to Netdata v1.47.5
 - Rework patch for gcc 4.8 build errors


### PR DESCRIPTION
LogNamespace= has been introduced in v245 so it's not supported by XCP-ng 8.3 systemd v219. Remove it to avoid warnings when checking service units correctness.