### PR TITLE
Fix %patch macro for compatibility with RPM 4.20 and above

### DIFF
--- a/SPECS/netdata.spec
+++ b/SPECS/netdata.spec
@@ -68,7 +68,7 @@ ExcludeArch: s390x
 
 Name:           netdata
 Version:        %{upver}%{?rcver:~%{rcver}}
-Release:        4.2%{?dist}
+Release:        4.3%{?dist}
 Summary:        Real-time performance monitoring
 # For a breakdown of the licensing, see license REDISTRIBUTED.md
 License:        GPL-3.0-or-later
@@ -306,11 +306,11 @@ fi
 
 %prep
 %setup -qn %{name}-%{upver}%{?rcver:-%{rcver}}
-%patch -P0 -p1
-%patch -P1 -p1
+%patch -P 0 -p1
+%patch -P 1 -p1
 %if 0%{?fedora}
 # Remove embedded font(added in requires)
-%patch -P10 -p1
+%patch -P 10 -p1
 rm -rf src/web/gui/v1/fonts/
 %endif
 # Remove closed source parts if present
@@ -319,10 +319,10 @@ if [ -d src/web/gui/v2 ] ; then
     cp -a src/web/gui/v1/index.html src/web/gui/index.html
 fi
 
-%patch1000 -p1
-%patch1001 -p1
-%patch1002 -p1
-%patch1003 -p1
+%patch -P 1000 -p1
+%patch -P 1001 -p1
+%patch -P 1002 -p1
+%patch -P 1003 -p1
 
 cp %{SOURCE5} .
 ### BEGIN netdata cloud
@@ -643,6 +643,10 @@ fi
 
 
 %changelog
+* Wed May 06 2026 Vincent Michel <vincent.michel@vates.tech> - 1.47.5-4.3
+- Fix the %%patch macro in the specfile to be compatible with rpm 4.20 and above
+- Rebuild with openssl version 3
+
 * Wed Oct 01 2025 Thierry Escande <thierry.escande@vates.tech> - 1.47.5-4.2
 - Remove unsupported LogNamespace systemd service entry
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-2882

#### Related changes

Similar PRs in:
- [libreswan](https://github.com/xcp-ng-rpms/libreswan/pull/3)
- [fuse](https://github.com/xcp-ng-rpms/fuse/pull/1)
- [drbd](https://github.com/xcp-ng-rpms/drbd/pull/10)
- [netdata](https://github.com/xcp-ng-rpms/netdata/pull/9)
- [slang](https://github.com/xcp-ng-rpms/slang/pull/3)
- [systemtap](https://github.com/xcp-ng-rpms/systemtap/pull/3)

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Since [rpm 4.20.0]([https://rpm.org/releases/4.20.0](https://rpm.org/releases/4.20.0)
), the `%patchN` macro is no longer supported. This causes our `koji_build.py` script to fail if we happen to use rpm 4.20.0 or above (since the `specfile` python package is used to parse the RPM specfile). Here's the list of the affected repositories in [xcp-ng-rpms](https://github.com/xcp-ng-rpms):
- drbd
- fuse
- netdata
- slang
- systemtap

**Important note**: the previous builds used openssl version 1, we now use openssl version 3.

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

The users are not affected by this change.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

No consequence on existing setups

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

N/A

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

After enabling my user repo  (`sudo yum-config-manager --enable xcp-ng-vmichel1`), I ran:
```
± uv run pytest tests --hosts=10.30.36.1 -k netdata
```
The following tests pass:
```
<Dir xcp-ng-tests>
  <Package tests>
    <Dir packages>
      <Package netdata>
        <Module test_netdata.py>
          <Class TestsNetdata>
            <Function test_netdata_service>
            <Function test_netdata_conf>
            <Function test_netdata_webui>
    <Package xapi_plugins>
      <Package plugin_netdata>
        <Module test_netdata.py>
          <Class TestInstall>
            <Function test_is_netdata_installed>
            <Function test_install_netdata>
          <Class TestApiKey>
            <Function test_get_netdata_api_key>
```


#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

A simple test would be to install `netdata-ui` and then browse to `http://<host>:19999`.
The web UI for netdata should appear.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->
```
<Dir xcp-ng-tests>
  <Package tests>
    <Dir packages>
      <Package netdata>
        <Module test_netdata.py>
          <Class TestsNetdata>
            <Function test_netdata_service>
            <Function test_netdata_conf>
            <Function test_netdata_webui>
    <Package xapi_plugins>
      <Package plugin_netdata>
        <Module test_netdata.py>
          <Class TestInstall>
            <Function test_is_netdata_installed>
            <Function test_install_netdata>
          <Class TestApiKey>
            <Function test_get_netdata_api_key>
```
#### What tests have been or will be added to CI for this change? If none, explain why.

None, because the sources haven't changed.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
